### PR TITLE
fix : ZRWC-28 : docker-compose 파일에 redis 컨테이너 볼륨 세팅추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,11 @@ services:
   redis:
     container_name: redis
     image: redis
+    volumes:
+      - redis_data:/data
     ports:
       - "6379:6379"
 
 volumes:
   postgres_data:
+  redis_data:


### PR DESCRIPTION
## Jira 티켓
[ZRWC-28](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2/timeline?selectedIssue=ZRWC-28)

## 제목

docker-compose 파일에 redis 컨테이너 볼륨 세팅추가

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- docker-compose 파일에서 레디스 컨테이너 볼륨 관련 세팅 없음

## 변경 후

- docker-compose 파일에서 레디스 컨테이너 볼륨 관련 세팅 추가
