### PR TITLE
refactor : ZRWC-53 : WorflowRepository 및 JobRepository의 get 메서드에 exception handling 구문 추가

### DIFF
--- a/workflow_engine/project_apps/repository/job_repository.py
+++ b/workflow_engine/project_apps/repository/job_repository.py
@@ -15,10 +15,17 @@ class JobRepository:
         )
         
         return job
-        
+
     def get_job(self, job_uuid):
-        job = Job.objects.get(uuid=job_uuid)
-        return job
+        try:
+            job = Job.objects.get(uuid=job_uuid)
+            return job
+        except ObjectDoesNotExist:
+            return {'status': 'error', 'message': 'Workflow not found'}
+        except MultipleObjectsReturned:
+            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
+        except Exception as e:
+            return {'status': 'error', 'message': str(e)}
 
     def update_job(self, job_uuid, name, image, parameters, next_job_names, depends_count):
         job = Job.objects.get(uuid=job_uuid)

--- a/workflow_engine/project_apps/repository/workflow_repository.py
+++ b/workflow_engine/project_apps/repository/workflow_repository.py
@@ -9,8 +9,15 @@ class WorkflowRepository:
         return workflow
 
     def get_workflow(self, workflow_uuid):
-        workflow = Workflow.objects.get(uuid=workflow_uuid)
-        return workflow
+        try:
+            workflow = Workflow.objects.get(uuid=workflow_uuid)
+            return workflow
+        except ObjectDoesNotExist:
+            return {'status': 'error', 'message': 'Workflow not found'}
+        except MultipleObjectsReturned:
+            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
+        except Exception as e:
+            return {'status': 'error', 'message': str(e)}
 
     def update_workflow(self, workflow_uuid, name, description):
         workflow = Workflow.objects.get(uuid=workflow_uuid)


### PR DESCRIPTION
## Jira 티켓

[ZRWC-53](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-53)

## 제목

`WorflowRepository` 및 `JobRepository`의 `get` 메서드에 exception handling 구문 추가

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- `WorflowRepository` 및 `JobRepository` 클래스의 `get` 메서드에서 발생가능한 exception에 대한 처리 구문 없음

## 변경 후

- `WorflowRepository` 및 `JobRepository` 클래스의 `get` 메서드에서 발생가능한 exception에 대한 handling 구문 추가
