### PR TITLE
refactor : ZRWC-71 : 순환 임포트 문제 해결

### DIFF
--- a/workflow_engine/project_apps/engine/job_dependency.py
+++ b/workflow_engine/project_apps/engine/job_dependency.py
@@ -5,7 +5,8 @@ from celery.exceptions import SoftTimeLimitExceeded
 
 from project_apps.constants import JOB_STATUS_WAITING
 from project_apps.models.cache import Cache
-from project_apps.engine.job_execute import job_execute
+from project_apps.engine.tasks_manager import job_execute
+
 
 @shared_task
 def job_dependency(workflow_uuid, history_uuid):
@@ -20,7 +21,7 @@ def job_dependency(workflow_uuid, history_uuid):
 
         for job_data in job_list:
             if job_data['depends_count'] == 0 and job_data['result'] == JOB_STATUS_WAITING:
-                job_execute.apply_async(args=[workflow_uuid, history_uuid, job_data['uuid']])
+                job_execute(workflow_uuid, history_uuid, job_data['uuid'])
 
         return {'status': 'success', 'message': 'Jobs execution started successfully'}
 

--- a/workflow_engine/project_apps/engine/job_execute.py
+++ b/workflow_engine/project_apps/engine/job_execute.py
@@ -4,12 +4,12 @@ from requests.exceptions import ReadTimeout, ConnectionError
 
 from project_apps.constants import JOB_STATUS_RUNNING, JOB_STATUS_SUCCESS, JOB_STATUS_FAIL
 from project_apps.repository.history_repository import HistoryRepository
+from project_apps.service.workflow_service import WorkflowExecutor
 
 
 @shared_task
 def job_execute(workflow_uuid, history_uuid, job_uuid):
     client = docker.from_env()
-    from project_apps.service.workflow_service import WorkflowExecutor
     workflow_executor = WorkflowExecutor()
     history_repo = HistoryRepository()
 

--- a/workflow_engine/project_apps/engine/tasks_manager.py
+++ b/workflow_engine/project_apps/engine/tasks_manager.py
@@ -1,0 +1,13 @@
+from celery import current_app
+
+def job_execute(workflow_uuid, history_uuid, job_uuid):
+    '''
+    job을 실제 수행하는 celery task
+    '''
+    current_app.send_task('project_apps.engine.job_execute.job_execute', args=[workflow_uuid, history_uuid, job_uuid])
+
+def job_dependency(workflow_uuid, history_uuid):
+    '''
+    job 의존성 관련 celery task
+    '''
+    current_app.send_task('project_apps.engine.job_dependency.job_dependency', args=[workflow_uuid, history_uuid])

--- a/workflow_engine/project_apps/service/workflow_service.py
+++ b/workflow_engine/project_apps/service/workflow_service.py
@@ -5,7 +5,7 @@ from django.db import transaction
 
 from project_apps.api.serializers import serialize_workflow
 from project_apps.constants import HISTORY_STATUS_FAIL, HISTORY_STATUS_SUCCESS, JOB_STATUS_SUCCESS, JOB_STATUS_WAITING
-from project_apps.engine.job_dependency import job_dependency
+from project_apps.engine.tasks_manager import job_dependency
 from project_apps.models.cache import Cache
 from project_apps.repository.history_repository import HistoryRepository
 from project_apps.repository.job_repository import JobRepository
@@ -192,7 +192,7 @@ class WorkflowExecutor:
             job_list_json = json.dumps(job_list)
             self.cache.set(workflow_uuid, job_list_json)
             history = self.history_repository.create_history(workflow_uuid)
-            job_dependency.apply_async(args=[workflow_uuid, history.uuid])
+            job_dependency(workflow_uuid, history.uuid)
 
             return True
         else:
@@ -223,6 +223,9 @@ class WorkflowExecutor:
             self.cache.set(workflow_uuid, json.dumps(workflow_data))
 
     def handle_success(self, job_data, workflow_uuid, history_uuid, history_repo):
+        '''
+        성공한 작업을 처리하고, 해당 작업에 의존하는 다음 작업들의 상태를 업데이트.
+        '''
         updated = False 
 
         with self.lock:
@@ -240,7 +243,7 @@ class WorkflowExecutor:
                 self.cache.set(workflow_uuid, json.dumps(workflow_data))
 
         if updated:
-            job_dependency.apply_async(args=[workflow_uuid, history_uuid])
+            job_dependency(workflow_uuid, history_uuid)
 
         self.check_workflow_completion(workflow_uuid, history_uuid, history_repo)
 


### PR DESCRIPTION
## Jira 티켓

[ZRWC-71](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-71)

## 제목

순환 임포트 문제 해결

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- workflow_service.py  `execute_workflow` 메소드에서 job_dependency.py `job_dependency` celery task 함수를 임포트 후 호출 하고,  `job_dependency` 메소드에서  job_execute.py `job_execute` celery task 함수를 임포트 후 호출하고 있고 `job_execute`에서는  workflow_service.py `WorkflowExecutor` 클래스를 임포트 후 호출함으로써 순환 임포트 문제(파이썬에서 둘 이상의 모듈들이 서로를 임포트할 때 순환 임포트 문제가 발생)가 발생하였음.

## 변경 후

- tasks_manager.py 라는 새로운 파일을 생성하여 `job_execute` 및 `job_dependency` celery task를 호출하는 함수들을 중앙에서 관리하는 역할을 하는 파일을 생성하였음.
- task들을 중앙에서 관리하는 방식을 사용하면 task가 정의가 있는 모듈을 직접 임포트하지 않아도 되므로, 모듈 간 결합도를 낮추고 순환 임포트 문제를 해결 할 수 있음.