### PR TITLE
refactor : ZRWC-87 : update_history_status 메소드 리팩토링

### DIFF
--- a/workflow_engine/project_apps/repository/history_repository.py
+++ b/workflow_engine/project_apps/repository/history_repository.py
@@ -19,5 +19,5 @@ class HistoryRepository:
         '''
         워크플로우가 성공적으로 종료 될 경우 또는 실패 할 경우 워크플로우의 실행 이력(history) 상태를 업데이트.
         '''
-        completed_at = timezone.now() if status != HISTORY_STATUS_SUCCESS else None
+        completed_at = timezone.now()
         History.objects.filter(uuid=history_uuid).update(status=status, completed_at=completed_at)


### PR DESCRIPTION
## Jira 티켓

[ZRWC-87](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-87)

## 제목

history_repository update_history_status 메소드 리팩토링

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 워크플로우가 성공적으로 종료 될때에는 completed_at에 None 값이 들어가고, 워크플로우가 실패 처리 되었을 경우에만 completed_at에 현재 시간에 해당하는 값이 들어감.

## 변경 후

- 워크플로우의 성공/실패에 상관없이 모두 completed_at 칼럼에 워크플로우가 종료 된 시점의 시간 값이 들어가도록 수정.
