### PR TITLE
refactor : ZRWC-88 : job을 실행하는 로직과 job 의존성 관련 로직을 분리

### DIFF
--- a/workflow_engine/project_apps/engine/job_dependency.py
+++ b/workflow_engine/project_apps/engine/job_dependency.py
@@ -3,6 +3,7 @@ import json
 from celery import shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 
+from project_apps.constants import JOB_STATUS_WAITING
 from project_apps.models.cache import Cache
 from project_apps.engine.job_execute import job_execute
 
@@ -18,7 +19,7 @@ def job_dependency(workflow_uuid, history_uuid):
         job_list = json.loads(job_list_json)
 
         for job_data in job_list:
-            if job_data['depends_count'] == 0:
+            if job_data['depends_count'] == 0 and job_data['result'] == JOB_STATUS_WAITING:
                 job_execute.apply_async(args=[workflow_uuid, history_uuid, job_data['uuid']])
 
         return {'status': 'success', 'message': 'Jobs execution started successfully'}


### PR DESCRIPTION
## Jira 티켓

[ZRWC-88](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-88)

## 제목

job을 실행하는 로직과 job 의존성 관련 로직을 분리

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- job_dependency celery 태스크 함수가 있음에도 워크플로우를 처음 실행시킬때에만 사용 되고 이후에는 사용 되고 있지않다.
- 그로인해, job_execute celery 태스크 함수에 job 실행에 관련 로직 뿐만 아니라 job 의존성 관련 로직도 관리하고 있어서 너무 많은 책임을 job_execute celery 태스크가 지고있다.

## 변경 후

- job_dependency celery 태스크 함수에 의존성 관련 로직을 추가하고 job_dependency celery 태스크 함수에서만 job_execute celery 태스크를 호출할 수 있도록 수정하였다.
- 그로인해, 의존성 처리와 작업 실행 로직을 더욱 명확하게 분리하고, 전체적인 코드의 구조를 개선하였음.