### PR TITLE
refactor : ZRWC-91 : 워크플로우 Delete API 요청 시에 발생하는 에러를 수정한다.

### DIFF
--- a/workflow_engine/project_apps/service/workflow_service.py
+++ b/workflow_engine/project_apps/service/workflow_service.py
@@ -139,7 +139,7 @@ class WorkflowService:
 
         # Jobs 삭제
         for job in jobs:
-            self.job_repository.delete_job(job.uuid)
+            self.job_repository.delete_job(job['uuid'])
 
     def get_workflow_list(self):
         workflows = self.workflow_repository.get_workflow_list()


### PR DESCRIPTION
## Jira 티켓

[ZRWC-91](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-91)
## 제목

워크플로우 Delete API 요청 시에 발생하는 에러를 수정한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 발생 에러: “AttributeError: 'dict' object has no attribute 'uuid'“
- 발생 이유: 구현 시에는 get_job_list 를 통해 반환되는 값이 ‘Job’ 모델의 인스턴스를 반환했기 때문에 현재 구현된 코드가 잘 동작하였는데, 차후에 반환 값이 딕셔너리 형태로 바뀌어서 발생한 에러입니다.

## 변경 후

- get_job_list 함수의 반환 값에서 딕셔너리 key가 'uuid'인 값을 받아오도록 수정하였습니다.
- 수정 후, 더 이상 에러 없이 워크플로우의 Delete API 요청이 성공적으로 동작하는 것을 확인하였습니다.