### PR TITLE
refactor : ZRWC-92 : 워크플로우 CRUD API 뷰 클래스를 하나로 통합한다.

### DIFF
--- a/workflow_engine/project_apps/api/urls.py
+++ b/workflow_engine/project_apps/api/urls.py
@@ -1,12 +1,10 @@
 from django.urls import path
 
-from project_apps.api.views import WorkflowCreateAPIView, WorkflowReadAPIView, WorkflowListReadAPIView, WorkflowUpdateAPIView, WorkflowDeleteAPIView, WorkflowExecuteAPIView
+from project_apps.api.views import WorkflowAPIView, WorkflowListReadAPIView, WorkflowExecuteAPIView
 
 urlpatterns = [
-    path('workflow', WorkflowCreateAPIView.as_view()),
-    path('workflow/<uuid:workflow_uuid>', WorkflowReadAPIView.as_view()),
-    path('workflow/<uuid:workflow_uuid>', WorkflowUpdateAPIView.as_view()),
-    path('workflow/<uuid:workflow_uuid>', WorkflowDeleteAPIView.as_view()),
+    path('workflow', WorkflowAPIView.as_view()),
+    path('workflow/<uuid:workflow_uuid>', WorkflowAPIView.as_view()),
     path('workflow/list', WorkflowListReadAPIView.as_view()),
     path('workflow/execute/<uuid:workflow_uuid>', WorkflowExecuteAPIView.as_view()),
 ]

--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from project_apps.service.workflow_service import WorkflowService
 
 
-class WorkflowCreateAPIView(APIView):
+class WorkflowAPIView(APIView):
     '''
     API View for creating a new Workflow instance along with associated Job instances.
     '''
@@ -27,8 +27,6 @@ class WorkflowCreateAPIView(APIView):
         
         return Response(workflow, status=status.HTTP_201_CREATED)
 
-
-class WorkflowReadAPIView(APIView):
     '''
     API View for reading the corresponding workflow record.
     '''
@@ -44,8 +42,6 @@ class WorkflowReadAPIView(APIView):
         
         return Response(workflow, status=status.HTTP_200_OK)
 
-
-class WorkflowUpdateAPIView(APIView):
     '''
     API View for updating the corresponding workflow record.
     '''
@@ -64,8 +60,6 @@ class WorkflowUpdateAPIView(APIView):
 
         return Response(workflow, status=status.HTTP_200_OK)
 
-
-class WorkflowDeleteAPIView(APIView):
     '''
     API View for deleting a Workflow instance along with associated Job instances.
     '''


### PR DESCRIPTION
## Jira 티켓

[ZRWC-92](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-92)

## 제목

refactor : ZRWC-92 : 워크플로우 CRUD API 뷰 클래스를 하나로 통합한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 워크플로우의 CRUD API 뷰 클래스가 각각 나눠져 었었다.
- Read, Update, Delete API 뷰 클래스가 같은 URL 패턴을 사용하였다.
- Django에서는 URL 패턴을 처리할 때 가장 먼저 매칭되는 뷰(Read 뷰 함수)만 사용해서, Update, Delete 요청시에 에러가 발생한다.

## 변경 후

- 워크플로우의 CRUD API 뷰 클래스를 하나의 WorkflowAPIView 클래스로 통합하였다.
- 동일한 URL 패턴을 사용하더라도 같은 뷰 클래스에서 사용하는 메서드가 다르기 때문에 다른 요청에 대해서 정상적으로 동작한다.
