### PR TITLE
refactor : ZRWC-72 : Job 테이블의 parameters, next_job_names 필드를 JSON으로 파…

### DIFF
--- a/workflow_engine/project_apps/engine/job_execute.py
+++ b/workflow_engine/project_apps/engine/job_execute.py
@@ -21,8 +21,8 @@ def job_execute(workflow_uuid, history_uuid, job_uuid):
     try:
         workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_RUNNING)
         image = client.images.pull(job_data['image'])
-        environment = json.loads(job_data.get('parameters'))
-        container = client.containers.run(image, detach=True, environment=environment)
+        environment = json.loads(job_data.get('parameters', '{}'))
+        container = client.containers.run(image, detach=True, environment=environment, tty=True)
         result = container.wait(timeout=60)
         
         if result['StatusCode'] == 0:

--- a/workflow_engine/project_apps/service/workflow_manage.py
+++ b/workflow_engine/project_apps/service/workflow_manage.py
@@ -51,9 +51,10 @@ class WorkflowManager:
 
         with self.lock:
             workflow_data = json.loads(self.cache.get(workflow_uuid))
-            if 'next_job_names' in job_data and job_data['next_job_names']:
-                next_job_names_str = job_data['next_job_names'].strip("[]")
-                next_job_names = [name.strip(" '\"") for name in next_job_names_str.split(',')]
+            next_job_names_str = job_data.next_job_names
+            next_job_names = json.loads(next_job_names_str)
+
+            if next_job_names: 
                 for next_job_name in next_job_names:
                     for job in workflow_data:
                         if job['name'] == next_job_name:


### PR DESCRIPTION
## Jira 티켓

[ZRWC-72](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-72)

## 제목

refactor : ZRWC-72 : Job 테이블의 parameters, next_job_names 필드를 JSON으로 파싱한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- Job 테이블의 parameters 칼럼을 사용하지 않았음.
- Job 테이블의 next_job_names 칼럼을 문자열로 받아서 사용했음.

## 변경 후

- Job 테이블의 parameters, next_job_names 필드를 JSON으로 파싱하여 사용한다.
