### PR TITLE
feat : ZRWC-94 : 스케줄링 Create API를 구현한다.

### DIFF
--- a/workflow_engine/project_apps/api/urls.py
+++ b/workflow_engine/project_apps/api/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from project_apps.api.views import WorkflowAPIView, WorkflowListReadAPIView, WorkflowExecuteAPIView
+from project_apps.api.views import WorkflowAPIView, WorkflowListReadAPIView, WorkflowExecuteAPIView, SchedulingAPIView
 
 urlpatterns = [
     path('workflow', WorkflowAPIView.as_view()),
     path('workflow/<uuid:workflow_uuid>', WorkflowAPIView.as_view()),
     path('workflow/list', WorkflowListReadAPIView.as_view()),
     path('workflow/execute/<uuid:workflow_uuid>', WorkflowExecuteAPIView.as_view()),
+    path('workflow/scheduling', SchedulingAPIView.as_view()),
 ]

--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework import status
 
 from project_apps.service.workflow_service import WorkflowService
+from project_apps.service.scheduling_service import SchedulingService
 
 
 class WorkflowAPIView(APIView):
@@ -103,3 +104,25 @@ class WorkflowExecuteAPIView(APIView):
             return Response(status=status.HTTP_204_NO_CONTENT)
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+
+class SchedulingAPIView(APIView):
+    '''
+    API View for creating a new Scheduling instance.
+    '''
+    def post(self, request):
+        workflow_uuid = request.data.get('workflow_uuid')
+        scheduled_at = request.data.get('scheduled_at')
+        interval = request.data.get('interval')
+        is_active = request.data.get('is_active')
+
+        if not workflow_uuid:
+            return Response({'error': 'workflow_uuid is required.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        scheduling_service = SchedulingService()
+        try:
+            scheduling = scheduling_service.create_scheduling(workflow_uuid, scheduled_at, interval, is_active)
+        except ValidationError as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(scheduling, status=status.HTTP_201_CREATED)

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -1,0 +1,7 @@
+from project_apps.models import Scheduling
+
+
+class SchedulingRepository:
+    def create_scheduling(self, workflow_uuid, scheduled_at, interval, is_active):
+        scheduling = Scheduling.objects.create(workflow_uuid=workflow_uuid, scheduled_at=scheduled_at, interval=interval, is_active=is_active)
+        return scheduling

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -1,0 +1,25 @@
+from project_apps.repository.scheduling_repository import SchedulingRepository
+
+
+class SchedulingService:
+    def __init__(self):
+        self.scheduling_repository = SchedulingRepository()
+
+    def create_scheduling(self, workflow_uuid, scheduled_at, interval, is_active):
+        scheduling = self.scheduling_repository.create_scheduling(
+            workflow_uuid=workflow_uuid, 
+            scheduled_at=scheduled_at,
+            interval=interval,
+            is_active=is_active,
+        )
+
+        # 스케줄링 정보 생성
+        scheduling_info = {
+            'uuid': scheduling.uuid,
+            'workflow_uuid': scheduling.workflow_uuid,
+            'scheduled_at': scheduling.scheduled_at,
+            'interval': scheduling.interval,
+            'is_active': scheduling.is_active,
+        }
+
+        return scheduling_info


### PR DESCRIPTION
## Jira 티켓

[ZRWC-94](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-94)

## 제목

스케줄링 Create API를 구현한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 스케줄링 Create API 뷰 함수가 구현되지 않음.

## 변경 후

- 스케줄링 API 뷰 클래스 생성.
    - 스케줄링 CURD API 뷰 클래스는 SchedulingAPIView 하나로 통합.
- 스케줄링 Create API의 URL 패턴은 ‘/sheduling’으로 함.
- 스케줄링 Create API 뷰 함수 구현.
    - API 뷰 함수 → scheduling_service 함수 → scheduling_repository 함수
    - 기존 워크플로우 API 뷰 함수와 동일한 모듈화된 함수 호출 구조.