### PR TITLE
feat : ZRWC-95 : 스케줄링 Read API를 구현한다.

### DIFF
--- a/workflow_engine/project_apps/api/urls.py
+++ b/workflow_engine/project_apps/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from project_apps.api.views import WorkflowAPIView, WorkflowListReadAPIView, WorkflowExecuteAPIView, SchedulingAPIView, SchedulingAPIView
+from project_apps.api.views import WorkflowAPIView, WorkflowListReadAPIView, WorkflowExecuteAPIView, SchedulingAPIView, SchedulingListReadAPIView
 
 urlpatterns = [
     path('workflow', WorkflowAPIView.as_view()),
@@ -9,4 +9,5 @@ urlpatterns = [
     path('workflow/execute/<uuid:workflow_uuid>', WorkflowExecuteAPIView.as_view()),
     path('workflow/scheduling', SchedulingAPIView.as_view()),
     path('workflow/scheduling/<uuid:scheduling_uuid>', SchedulingAPIView.as_view()),
+    path('workflow/scheduling/list/<uuid:workflow_uuid>', SchedulingListReadAPIView.as_view()),
 ]

--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -127,6 +127,21 @@ class SchedulingAPIView(APIView):
         return Response(scheduling, status=status.HTTP_201_CREATED)
 
     '''
+    API View for reading the corresponding scheduling record.
+    '''
+    def get(self, request, scheduling_uuid):
+        if not scheduling_uuid:
+            return Response({'error': 'scheduling uuid is required.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        scheduling_service = SchedulingService()
+        try:
+            scheduling = scheduling_service.get_scheduling(scheduling_uuid)
+        except ValidationError as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(scheduling, status=status.HTTP_200_OK)
+
+    '''
     API View for updating the corresponding scheduling record.
     '''
     def patch(self, request, scheduling_uuid):
@@ -156,3 +171,14 @@ class SchedulingAPIView(APIView):
 
         return Response({'success': f'Scheduling with uuid {scheduling_uuid} deleted successfully.'},
                         status=status.HTTP_204_NO_CONTENT)
+
+
+class SchedulingListReadAPIView(APIView):
+    '''
+    API View for reading the whole scheduling list.
+    '''
+    def get(self, request, workflow_uuid):
+        scheduling_service = SchedulingService()
+        scheduling_list = scheduling_service.get_scheduling_list(workflow_uuid)
+
+        return Response(scheduling_list, status=status.HTTP_200_OK)

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -18,7 +18,7 @@ class SchedulingRepository:
             return {'status': 'error', 'message': 'Multiple schedulings found with the same UUID'}
         except Exception as e:
             return {'status': 'error', 'message': str(e)}
-    
+
     def get_scheduling_list(self, workflow_uuid):
         scheduling_list = Scheduling.objects.filter(workflow_uuid=workflow_uuid).values('uuid', 'workflow_uuid', 'scheduled_at', 'interval', 'is_active', 'created_at', 'updated_at')
         return list(scheduling_list.values())

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -7,6 +7,21 @@ class SchedulingRepository:
     def create_scheduling(self, workflow_uuid, scheduled_at, interval, is_active):
         scheduling = Scheduling.objects.create(workflow_uuid=workflow_uuid, scheduled_at=scheduled_at, interval=interval, is_active=is_active)
         return scheduling
+    
+    def get_scheduling(self, scheduling_uuid):
+        try:
+            scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
+            return scheduling
+        except ObjectDoesNotExist:
+            return {'status': 'error', 'message': 'Scheduling not found'}
+        except MultipleObjectsReturned:
+            return {'status': 'error', 'message': 'Multiple schedulings found with the same UUID'}
+        except Exception as e:
+            return {'status': 'error', 'message': str(e)}
+    
+    def get_scheduling_list(self, workflow_uuid):
+        scheduling_list = Scheduling.objects.filter(workflow_uuid=workflow_uuid).values('uuid', 'workflow_uuid', 'scheduled_at', 'interval', 'is_active', 'created_at', 'updated_at')
+        return list(scheduling_list.values())
 
     def update_scheduling(self, scheduling_uuid, scheduled_at, interval, is_active):
         try:

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -30,7 +30,7 @@ class SchedulingService:
         }
 
         return scheduling_info
-    
+
     def get_scheduling_list(self, workflow_uuid):
         schedulings = self.scheduling_repository.get_scheduling_list(workflow_uuid)
         schedulings_info = []

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -16,6 +16,36 @@ class SchedulingService:
             interval=interval,
             is_active=is_active,
         )
+  
+    def get_scheduling(self, scheduling_uuid):
+        scheduling = self.scheduling_repository.get_scheduling(scheduling_uuid)
+        scheduling_info = {
+            'uuid': scheduling.uuid,
+            'workflow_uuid': scheduling.workflow_uuid,
+            'scheduled_at': scheduling.scheduled_at,
+            'interval': scheduling.interval,
+            'is_active': scheduling.is_active,
+            'created_at': scheduling.created_at,
+            'updated_at': scheduling.updated_at
+        }
+
+        return scheduling_info
+    
+    def get_scheduling_list(self, workflow_uuid):
+        schedulings = self.scheduling_repository.get_scheduling_list(workflow_uuid)
+        schedulings_info = []
+        for scheduling in schedulings:
+            schedulings_info.append({
+                'uuid': scheduling['uuid'],
+                'workflow_uuid': scheduling['workflow_uuid'],
+                'scheduled_at': scheduling['scheduled_at'],
+                'interval': scheduling['interval'],
+                'is_active': scheduling['is_active'],
+                'created_at': scheduling['created_at'],
+                'updated_at': scheduling['updated_at'],
+            })
+
+        return schedulings_info
 
     @transaction.atomic
     def update_scheduling(self, scheduling_uuid, scheduling_data):


### PR DESCRIPTION
## Jira 티켓

[ZRWC-95](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-95)

## 제목

스케줄링 Read API를 구현한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 스케줄링 Read API 뷰 함수가 구현되지 않음.
-스케줄링 리스트 Read API 뷰 함수가 구현되지 않음.

## 변경 후

- 스케줄링 CURD API 뷰 클래스는 SchedulingAPIView 하나로 통합.
- 스케줄링 리스트 Read API 뷰 클래스를 SchedulingListAPIVIew 로 생성.
- 스케줄링 Read API의 URL 패턴은 ‘/sheduling/<uuid:schedulling_uuid>’으로 함.
- 워크플로우에 따른 스케줄링 리스트 Read API의 URL 패턴은 '/scheduling/list/<uuid:workflow_uuid>'으로 함.
- 스케줄링 Read API 뷰 함수 구현.
    - API 뷰 함수 → scheduling_service 함수 → scheduling_repository 함수
    - 기존 워크플로우 API 뷰 함수와 동일한 모듈화된 함수 호출 구조.