### PR TITLE
feat : ZRWC-96 : 스케줄링 Update API를 구현한다.

### DIFF
--- a/workflow_engine/project_apps/api/urls.py
+++ b/workflow_engine/project_apps/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from project_apps.api.views import WorkflowAPIView, WorkflowListReadAPIView, WorkflowExecuteAPIView, SchedulingAPIView
+from project_apps.api.views import WorkflowAPIView, WorkflowListReadAPIView, WorkflowExecuteAPIView, SchedulingAPIView, SchedulingAPIView
 
 urlpatterns = [
     path('workflow', WorkflowAPIView.as_view()),
@@ -8,4 +8,5 @@ urlpatterns = [
     path('workflow/list', WorkflowListReadAPIView.as_view()),
     path('workflow/execute/<uuid:workflow_uuid>', WorkflowExecuteAPIView.as_view()),
     path('workflow/scheduling', SchedulingAPIView.as_view()),
+    path('workflow/scheduling/<uuid:scheduling_uuid>', SchedulingAPIView.as_view()),
 ]

--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -105,7 +105,6 @@ class WorkflowExecuteAPIView(APIView):
         else:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-
 class SchedulingAPIView(APIView):
     '''
     API View for creating a new Scheduling instance.
@@ -126,3 +125,20 @@ class SchedulingAPIView(APIView):
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(scheduling, status=status.HTTP_201_CREATED)
+
+    '''
+    API View for updating the corresponding scheduling record.
+    '''
+    def patch(self, request, scheduling_uuid):
+        scheduling_data = request.data
+
+        if not scheduling_uuid:
+            return Response({'error': 'scheduling uuid is required.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        scheduling_service = SchedulingService()
+        try:
+            scheduling = scheduling_service.update_scheduling(scheduling_uuid, scheduling_data)
+        except ValidationError as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(scheduling, status=status.HTTP_200_OK)

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+
 from project_apps.models import Scheduling
 
 
@@ -5,3 +7,20 @@ class SchedulingRepository:
     def create_scheduling(self, workflow_uuid, scheduled_at, interval, is_active):
         scheduling = Scheduling.objects.create(workflow_uuid=workflow_uuid, scheduled_at=scheduled_at, interval=interval, is_active=is_active)
         return scheduling
+    
+    def update_scheduling(self, scheduling_uuid, scheduled_at, interval, is_active):
+        try:
+            scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
+            
+            for arg, val in locals().items():
+                if val is not None:
+                    setattr(scheduling, arg, val)
+            scheduling.save()
+
+            return scheduling
+        except ObjectDoesNotExist:
+            return {'status': 'error', 'message': 'Scheduling not found'}
+        except MultipleObjectsReturned:
+            return {'status': 'error', 'message': 'Multiple schedulings found with the same UUID'}
+        except Exception as e:
+            return {'status': 'error', 'message': str(e)}

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -1,3 +1,5 @@
+from django.db import transaction
+
 from project_apps.repository.scheduling_repository import SchedulingRepository
 
 
@@ -13,13 +15,22 @@ class SchedulingService:
             is_active=is_active,
         )
 
-        # 스케줄링 정보 생성
+    @transaction.atomic
+    def update_scheduling(self, scheduling_uuid, scheduling_data):
+        scheduling = self.scheduling_repository.update_scheduling(
+            scheduling_uuid,
+            scheduled_at=scheduling_data.get('scheduled_at'),
+            interval=scheduling_data.get('interval'),
+            is_active=scheduling_data.get('is_active'),
+        )
         scheduling_info = {
             'uuid': scheduling.uuid,
             'workflow_uuid': scheduling.workflow_uuid,
             'scheduled_at': scheduling.scheduled_at,
             'interval': scheduling.interval,
             'is_active': scheduling.is_active,
+            'created_at': scheduling.created_at,
+            'updated_at': scheduling.updated_at,
         }
 
         return scheduling_info


### PR DESCRIPTION
## Jira 티켓

[ZRWC-96](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-96)

## 제목

스케줄링 Update API를 구현한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 스케줄링 Update 뷰 함수가 구현되지 않음.

## 변경 후

- 스케줄링 CURD API 뷰 클래스는 SchedulingAPIView 하나로 통합.
- 스케줄링 Update API의 URL 패턴은 ‘/sheduling/<uuid:schedulling_uuid>’으로 함.
- 스케줄링 Update API 뷰 함수 구현.
    - API 뷰 함수 → scheduling_service 함수 → scheduling_repository 함수
    - 기존 워크플로우 API 뷰 함수와 동일한 모듈화된 함수 호출 구조.