### PR TITLE
feat : ZRWC-97 : 스케줄링 Delete API를 구현한다.

### DIFF
--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -142,3 +142,17 @@ class SchedulingAPIView(APIView):
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(scheduling, status=status.HTTP_200_OK)
+
+    '''
+    API View for deleting a scheduling instance.
+    '''
+    def delete(self, request, scheduling_uuid):
+        scheduling_service = SchedulingService()
+
+        try:
+            scheduling_service.delete_scheduling(scheduling_uuid)
+        except ValidationError as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response({'success': f'Scheduling with uuid {scheduling_uuid} deleted successfully.'},
+                        status=status.HTTP_204_NO_CONTENT)

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -7,7 +7,7 @@ class SchedulingRepository:
     def create_scheduling(self, workflow_uuid, scheduled_at, interval, is_active):
         scheduling = Scheduling.objects.create(workflow_uuid=workflow_uuid, scheduled_at=scheduled_at, interval=interval, is_active=is_active)
         return scheduling
-    
+
     def update_scheduling(self, scheduling_uuid, scheduled_at, interval, is_active):
         try:
             scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
@@ -22,5 +22,15 @@ class SchedulingRepository:
             return {'status': 'error', 'message': 'Scheduling not found'}
         except MultipleObjectsReturned:
             return {'status': 'error', 'message': 'Multiple schedulings found with the same UUID'}
+
+    def delete_scheduling(self, scheduling_uuid):
+        try:
+            scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
+            scheduling.delete()
+            return {'status': 'success', 'message': 'Scheduling deleted successfully'}
+        except ObjectDoesNotExist:
+            return {'status': 'error', 'message': 'Scheduling not found'}
+        except MultipleObjectsReturned:
+            return {'status': 'error', 'message': 'Multiple Schedulings found with the same UUID'}
         except Exception as e:
             return {'status': 'error', 'message': str(e)}

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -1,3 +1,5 @@
+import orjson as json
+
 from django.db import transaction
 
 from project_apps.repository.scheduling_repository import SchedulingRepository
@@ -34,3 +36,10 @@ class SchedulingService:
         }
 
         return scheduling_info
+
+    @transaction.atomic
+    def delete_scheduling(self, scheduling_uuid):
+        scheduling = self.scheduling_repository.get_scheduling(scheduling_uuid)
+
+        # scheduling 삭제
+        self.scheduling_repository.delete_scheduling(scheduling.uuid)


### PR DESCRIPTION
## Jira 티켓

[ZRWC-97](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-97)

## 제목

스케줄링 Delete API를 구현한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 스케줄링 Delete API 뷰 함수가 구현되지 않음.

## 변경 후

- 스케줄링 CURD API 뷰 클래스는 SchedulingAPIView 하나로 통합.
- 스케줄링 Delete API의 URL 패턴은 ‘/sheduling/<uuid:schedulling_uuid>’으로 함.
- 스케줄링 Delete API 뷰 함수 구현.
    - API 뷰 함수 → scheduling_service 함수 → scheduling_repository 함수
    - 기존 워크플로우 API 뷰 함수와 동일한 모듈화된 함수 호출 구조.