### PR TITLE
feat : ZRWC-86 : job task가 실패처리되었을 경우 해당 워크플로우의 실행중인 job task들도 모두 종료하는 로직 추가 구현

### DIFF
--- a/workflow_engine/project_apps/constants.py
+++ b/workflow_engine/project_apps/constants.py
@@ -7,3 +7,8 @@ JOB_STATUS_FAIL = 'fail'
 # History 상태
 HISTORY_STATUS_SUCCESS = 'success'
 HISTORY_STATUS_FAIL = 'fail'
+
+# Workflow 상태
+WORKFLOW_STATUS_RUNNING = 'running'
+WORKFLOW_STATUS_SUCCESS = 'success'
+WORKFLOW_STATUS_FAIL = 'fail'

--- a/workflow_engine/project_apps/engine/job_execute.py
+++ b/workflow_engine/project_apps/engine/job_execute.py
@@ -1,8 +1,9 @@
-import docker, json
+import docker
+from docker.errors import ImageNotFound, APIError
 from celery import shared_task
 from requests.exceptions import ReadTimeout, ConnectionError
 
-from project_apps.constants import JOB_STATUS_RUNNING, JOB_STATUS_SUCCESS, JOB_STATUS_FAIL
+from project_apps.constants import JOB_STATUS_RUNNING, JOB_STATUS_SUCCESS, JOB_STATUS_FAIL, WORKFLOW_STATUS_FAIL
 from project_apps.repository.history_repository import HistoryRepository
 from project_apps.service.workflow_manage import WorkflowManager
 
@@ -13,27 +14,45 @@ def job_execute(workflow_uuid, history_uuid, job_uuid):
     workflow_manager = WorkflowManager()
     history_repo = HistoryRepository()
 
+    if workflow_manager.check_workflow_status(workflow_uuid) == WORKFLOW_STATUS_FAIL:
+        return
+
     job_data = workflow_manager.find_job_data(workflow_uuid, job_uuid)
-    
     if not job_data:    
         return
 
     try:
-        workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_RUNNING)
+        if not workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_RUNNING):
+            return
         image = client.images.pull(job_data['image'])
-        environment = json.loads(job_data.get('parameters', '{}'))
-        container = client.containers.run(image, detach=True, environment=environment, tty=True)
+        container = client.containers.run(image, detach=True)
+        # environment = json.loads(job_data.get('parameters', '{}'))
+        # container = client.containers.run(image, detach=True, environment=environment, tty=True)
+        workflow_manager.add_container_to_running_list(workflow_uuid, container.id)
         result = container.wait(timeout=60)
         
         if result['StatusCode'] == 0:
-            workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_SUCCESS)
+            if not workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_SUCCESS):
+                return
             workflow_manager.handle_success(job_data, workflow_uuid, history_uuid, history_repo)
+            workflow_manager.remove_container_from_running_list(workflow_uuid, container.id)  
+            container.remove()
         else:
+            workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_FAIL)
             workflow_manager.handle_failure(history_uuid, workflow_uuid, history_repo)
-            
+    
+    except ImageNotFound as e:
+        workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_FAIL)
+        workflow_manager.handle_failure(history_uuid, workflow_uuid, history_repo)
+
+    except APIError as e:
+        workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_FAIL)
+        workflow_manager.handle_failure(history_uuid, workflow_uuid, history_repo)
+
     except (ReadTimeout, ConnectionError) as e:
         workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_FAIL)
         workflow_manager.handle_failure(history_uuid, workflow_uuid, history_repo)
 
     except Exception as e:
+        workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_FAIL)
         workflow_manager.handle_failure(history_uuid, workflow_uuid, history_repo)

--- a/workflow_engine/project_apps/engine/job_terminate.py
+++ b/workflow_engine/project_apps/engine/job_terminate.py
@@ -1,0 +1,17 @@
+import docker
+from celery import shared_task
+
+
+@shared_task
+def job_terminate(container_id):
+    '''
+    도커 컨테이너를 종료하는 Celery 태스크
+    '''
+    client = docker.from_env()
+    try:
+        container = client.containers.get(container_id)
+        if container.status == 'running':
+            container.kill()
+
+    except Exception as e:
+        print(f"Error terminating container {container_id}: {e}")

--- a/workflow_engine/project_apps/service/workflow_manage.py
+++ b/workflow_engine/project_apps/service/workflow_manage.py
@@ -1,6 +1,7 @@
 import orjson as json
 
-from project_apps.constants import HISTORY_STATUS_FAIL, HISTORY_STATUS_SUCCESS, JOB_STATUS_SUCCESS
+from project_apps.constants import HISTORY_STATUS_FAIL, HISTORY_STATUS_SUCCESS, JOB_STATUS_SUCCESS, WORKFLOW_STATUS_FAIL, WORKFLOW_STATUS_SUCCESS
+from project_apps.engine.job_terminate import job_terminate
 from project_apps.engine.tasks_manager import job_dependency
 from project_apps.models.cache import Cache
 from project_apps.repository.history_repository import HistoryRepository
@@ -34,12 +35,43 @@ class WorkflowManager:
         특정 작업의 상태를 업데이트하고, 변경된 워크플로우 데이터를 캐시에 저장.
         '''
         workflow_data = json.loads(self.cache.get(workflow_uuid))
-        for job in workflow_data:
-            if job['uuid'] == str(job_uuid):
-                job['result'] = status
-                break
-        
-        self.cache.set(workflow_uuid, json.dumps(workflow_data))
+
+        workflow_status = self.check_workflow_status(workflow_uuid)
+        if workflow_status == WORKFLOW_STATUS_FAIL:
+            for job in workflow_data:
+                if job['uuid'] == str(job_uuid):
+                    job['result'] = status
+                    print(f"{job['uuid'], job['result']}")
+                    break
+            self.cache.set(workflow_uuid, json.dumps(workflow_data))
+            return False
+        else:
+            for job in workflow_data:
+                if job['uuid'] == str(job_uuid):
+                    job['result'] = status
+                    print(f"{job['uuid'], job['result']}")
+                    break
+            self.cache.set(workflow_uuid, json.dumps(workflow_data))
+            return True
+
+    @with_lock
+    def update_workflow_status(self, workflow_uuid, status):
+        '''
+        워크플로우의 상태를 업데이트. 만약 상태가 실패로 업데이트된 경우, 
+		실행 중인 모든 도커 컨테이너를 종료
+        '''
+        self.cache.set(f"{workflow_uuid}_status", status)
+        if status == WORKFLOW_STATUS_FAIL:
+            running_containers = self.cache.get(f"{workflow_uuid}_running_containers")
+            if running_containers:
+                for container_id in running_containers:
+                    job_terminate.apply_async(args=[container_id])
+    
+    def check_workflow_status(self, workflow_uuid):
+        '''
+        워크플로우의 상태를 확인.
+        '''
+        return self.cache.get(f"{workflow_uuid}_status")
 
     @with_lock
     def handle_success(self, job_data, workflow_uuid, history_uuid, history_repo):
@@ -67,10 +99,10 @@ class WorkflowManager:
     def handle_failure(self, history_uuid, workflow_uuid, history_repo):
         '''
         작업 실행 실패 시 처리 로직을 수행.
-        관련 히스토리를 업데이트하고, 워크플로우 데이터를 캐시에서 삭제.
+        워크플로우 실패 상태를 설정하고, 관련 히스토리를 업데이트.
         '''
+        self.update_workflow_status(workflow_uuid, WORKFLOW_STATUS_FAIL)
         history_repo.update_history_status(history_uuid, HISTORY_STATUS_FAIL)
-        self.cache.delete(workflow_uuid)
 
     def check_workflow_completion(self, workflow_uuid, history_uuid, history_repo):
         '''
@@ -85,5 +117,24 @@ class WorkflowManager:
                 break
 
         if completed:
+            self.update_workflow_status(workflow_uuid, WORKFLOW_STATUS_SUCCESS)
             history_repo.update_history_status(history_uuid, HISTORY_STATUS_SUCCESS)
-            self.cache.delete(workflow_uuid)
+
+    @with_lock
+    def add_container_to_running_list(self, workflow_uuid, container_id):
+        '''
+        실행 중인 도커 컨테이너의 ID를 워크플로우의 실행중인 컨테이너 목록에 추가.
+        '''
+        running_containers = self.cache.get(f"{workflow_uuid}_running_containers")
+        running_containers.append(container_id)
+        self.cache.set(f"{workflow_uuid}_running_containers", running_containers)
+
+    @with_lock
+    def remove_container_from_running_list(self, workflow_uuid, container_id):
+        '''
+        워크플로우의 실행 중인 컨테이너 목록에서 특정 컨테이너의 ID를 제거.
+        '''
+        running_containers = self.cache.get(f"{workflow_uuid}_running_containers")
+        if container_id in running_containers:
+            running_containers.remove(container_id)
+            self.cache.set(f"{workflow_uuid}_running_containers", running_containers)


### PR DESCRIPTION
## Jira 티켓

[ZRWC-86](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-86)

## 제목

job task가 실패처리되었을 경우의 로직 및 워크플로우 실행 로직 수정.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- job이 실패처리 되더라도 동작 중인 job들이 멈추지않고 마지막 job까지 전부 실행되고 종료됨.
- 워크플로우가 성공 및 실패 상태로 변경되어 종료되었을 경우 레디스에 캐싱되어 있는 해당 워크플로우 데이터를 바로 삭제함.

## 변경 후

- 동일한 워크플로우에서 하나의 job이라도 실패 처리 되었을 시에, 다른 동작중인 job들도 실행을 멈추고 워크플로우를 종료하는 로직으로 수정.
- 워크플로우 실행 요청 시에 레디스에 해당 워크플로우 관련 캐싱되어있는 데이터들을 삭제 후 초기화를 하도록 수정.
