### PR TITLE
fix : ZRWC-104 : 워크플로우 리스트 Read API의 에러를 수정한다.

### DIFF
--- a/workflow_engine/workflow_engine/settings.py
+++ b/workflow_engine/workflow_engine/settings.py
@@ -69,7 +69,7 @@ DATABASES = {
         'NAME': env('POSTGRESQL_NAME'), # 데이터베이스 이름
         'USER': env('POSTGRESQL_USER'),
         'PASSWORD': env('POSTGRESQL_PWD'),
-        'HOST': 'db',
+        'HOST': 'localhost',
         'PORT': env('POSTGRESQL_PORT'),
     }
 }


### PR DESCRIPTION
## Jira 티켓

[ZRWC-104](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-104)

## 제목

워크플로우 리스트 Read API의 에러를 수정한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 기존의 코드에서는 반복문에서 workflows_info를 재할당하게 구현되었기 때문에 항상 마지막 workflow_info에 대한 정보만 저장 됨.
- 때문에 워크플로우 리스트 Read API 요청 시, 하나의 워크플로우 정보만 반환함.

## 변경 후

- workflows_info를 리스트로 유지하고, 각 workflow_info를 딕셔너리로 추가함.
- 워크플로우 리스트 Read API 요청 시, 모든 워크플로우의 정보를 담은 워크플로우 리스트가 정상적으로 반환됨.
