### PR TITLE
fix : ZRWC-104 : Job 테이블의 next_job_names 필드를 JSON으로 파싱하는 에러를 수정한다.

### DIFF
--- a/workflow_engine/project_apps/service/workflow_manage.py
+++ b/workflow_engine/project_apps/service/workflow_manage.py
@@ -49,9 +49,10 @@ class WorkflowManager:
         updated = False 
 
         workflow_data = json.loads(self.cache.get(workflow_uuid))
-        if 'next_job_names' in job_data and job_data['next_job_names']:
-            next_job_names_str = job_data['next_job_names'].strip("[]")
-            next_job_names = [name.strip(" '\"") for name in next_job_names_str.split(',')]
+        next_job_names_str = job_data.next_job_names
+        next_job_names = json.loads(next_job_names_str)
+
+        if next_job_names: 
             for next_job_name in next_job_names:
                 for job in workflow_data:
                     if job['name'] == next_job_name:


### PR DESCRIPTION
## Jira 티켓

[ZRWC-104](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-104)

## 제목

fix : ZRWC-104 : Job 테이블의 next_job_names 필드를 JSON으로 파싱하는 에러를 수정한다.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 기존 #33 PR에서 구현했던 Job 테이블의 next_job_names 필드를 JSON으로 파싱 하는 로직이 다른 PR과 꼬이면서 현재 해당 로직이 구현이 안 된 체 머지 되어 있음.

## 변경 후

- 이전에 구현했던 Job 테이블의 next_job_names 필드를 JSON으로 파싱하는 로직 추가.
