### PR TITLE
fix : ZRWC-108 : 워크플로우 Update API의 에러를 수정한다.

### DIFF
--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -47,8 +47,8 @@ class WorkflowAPIView(APIView):
     API View for updating the corresponding workflow record.
     '''
     def patch(self, request, workflow_uuid):
-        workflow_data = request.data.dict()
-        jobs_data = workflow_data.pop('jobs')
+        workflow_data = request.data
+        jobs_data = workflow_data.get('jobs', {})
 
         if not workflow_uuid:
             return Response({'error': 'workflow uuid is required.'}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Jira 티켓

[ZRWC-108](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-108)

## 제목

워크플로우 Update API의 에러를 수정한다.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- `AttributeError: 'dict' object has no attribute 'dict'` 에러를 발생시키며 워크플로우 update API가 정상 작동하지 않음.
- `jobs_data = workflow_data.pop('jobs')` 시도 시 `jobs` 키가 없을 때 `KeyError: 'jobs'`를 발생시킴.

## 변경 후

- `request.data`를 직접 받고(dict), `jobs` 키가 존재하지 않을때 빈 `jobs`(dict)를 반환하도록 수정함.
