### PR TITLE
fix : ZRWC-110 : 스케줄링 Create 로직을 수정한다.

### DIFF
--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -113,15 +113,14 @@ class SchedulingAPIView(APIView):
         workflow_uuid = request.data.get('workflow_uuid')
         scheduled_at = request.data.get('scheduled_at')
         interval = request.data.get('interval')
-        repeat_count = request.data.get('repeat_count')
-        is_active = request.data.get('is_active')
+        repeat_count = request.data.get('repeat_count', 0)
 
         if not workflow_uuid:
             return Response({'error': 'workflow_uuid is required.'}, status=status.HTTP_400_BAD_REQUEST)
 
         scheduling_service = SchedulingService()
         try:
-            scheduling = scheduling_service.create_scheduling(workflow_uuid, scheduled_at, interval, repeat_count, is_active)
+            scheduling = scheduling_service.create_scheduling(workflow_uuid, scheduled_at, interval, repeat_count)
         except ValidationError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -1,12 +1,22 @@
+from datetime import timedelta
+
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.utils.dateparse import parse_datetime
 
 from project_apps.models import Scheduling
 
 
 class SchedulingRepository:
-    def create_scheduling(self, workflow_uuid, scheduled_at, interval, repeat_count, is_active):
-        scheduling = Scheduling.objects.create(workflow_uuid=workflow_uuid, scheduled_at=scheduled_at, interval=interval, repeat_count=repeat_count, is_active=is_active)
-        return scheduling
+    def create_scheduling(self, workflow_uuid, scheduled_at, interval, repeat_count):
+        parse_scheduled_at = parse_datetime(scheduled_at) if scheduled_at else None
+        parse_interval = timedelta(**interval) if interval else None
+
+        scheduling = Scheduling.objects.create(
+            workflow_uuid=workflow_uuid, 
+            scheduled_at=parse_scheduled_at, 
+            interval=parse_interval, 
+            repeat_count=repeat_count
+        )
     
     def get_scheduling(self, scheduling_uuid):
         try:

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -9,13 +9,12 @@ class SchedulingService:
     def __init__(self):
         self.scheduling_repository = SchedulingRepository()
 
-    def create_scheduling(self, workflow_uuid, scheduled_at, interval, repeat_count, is_active):
+    def create_scheduling(self, workflow_uuid, scheduled_at, interval, repeat_count):
         scheduling = self.scheduling_repository.create_scheduling(
             workflow_uuid=workflow_uuid, 
             scheduled_at=scheduled_at,
             interval=interval,
-            repeat_count=repeat_count,
-            is_active=is_active,
+            repeat_count=repeat_count
         )
   
     def get_scheduling(self, scheduling_uuid):


### PR DESCRIPTION
## Jira 티켓

[ZRWC-110](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-110)

## 제목

스케줄링 Create 로직을 수정한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 스케줄링 생성 시 `is_active` 값을 입력받아야만 에러가 발생하지 않았음.
- 스케줄링 생성 시 `repeat_count` 값을 입력받아야만 에러가 발생하지 않았음.

## 변경 후

- `is_active` 필드는 스케줄링 레코드 생성 시 기본값인 `default` 값이 저장되도록 수정.
- `repeat_count`의 값이 입력되지 않았다면 기본값인 0으로 설정.
- 입력받은 `scheduled_at`, `interval` 값을 파싱해서 저장하도록 수정. (스케줄링 작업 시 파싱 된 값을 이용하기 위해서)