### PR TITLE
refactor : ZRWC-111 : 워크플로우 API의 serialize 과정을 리팩터링한다.

### DIFF
--- a/workflow_engine/project_apps/api/serializers.py
+++ b/workflow_engine/project_apps/api/serializers.py
@@ -5,25 +5,24 @@ def serialize_workflow(workflow_info, jobs_data):
     serialized_jobs = []
     for job_data in jobs_data:
         serialized_job = {
-            "uuid": job_data['uuid'],
-            "workflow_uuid": workflow_info['uuid'],
-            "name": job_data['name'],
-            "image": job_data.get('image', ''),
-            "parameters": job_data.get('parameters', {}),
-            "next_job_names": job_data.get('next_job_names', []),
-            "depends_count": job_data.get('depends_count', 0),
-            "timeout": job_data.get('timeout', 0),
-            "retries": job_data.get('retries', 0)
+            'uuid': job_data.uuid,
+            'name': job_data.name,
+            'image': job_data.image,
+            'parameters': job_data.parameters,
+            'next_job_names': job_data.next_job_names,
+            'depends_count': job_data.depends_count,
+            'timeout': job_data.timeout,
+            'retries': job_data.retries
         }
         serialized_jobs.append(serialized_job)
 
     serialized_workflow = {
-        "workflow": {
-            "uuid": workflow_info['uuid'],
-            "name": workflow_info['name'],
-            "description": workflow_info['description'],
-            "jobs": serialized_jobs
-        }
+        'uuid': workflow_info.uuid,
+        'name': workflow_info.name,
+        'description': workflow_info.description,
+        'created_at': workflow_info.created_at,
+        'updated_at': workflow_info.updated_at,
+        'jobs': serialized_jobs
     }
 
     return serialized_workflow

--- a/workflow_engine/project_apps/repository/job_repository.py
+++ b/workflow_engine/project_apps/repository/job_repository.py
@@ -59,5 +59,5 @@ class JobRepository:
             return {'status': 'error', 'message': str(e)}
 
     def get_job_list(self, workflow_uuid):
-        job_list = Job.objects.filter(workflow_uuid=workflow_uuid).values('uuid', 'name', 'image', 'parameters', 'next_job_names', 'depends_count', 'timeout', 'retries')
-        return list(job_list)
+        job_list = Job.objects.filter(workflow_uuid=workflow_uuid)
+        return job_list

--- a/workflow_engine/project_apps/repository/workflow_repository.py
+++ b/workflow_engine/project_apps/repository/workflow_repository.py
@@ -50,4 +50,4 @@ class WorkflowRepository:
 
     def get_workflow_list(self):
         workflow_list = Workflow.objects.all()
-        return list(workflow_list.values())
+        return workflow_list


### PR DESCRIPTION
## Jira 티켓

[ZRWC-111](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-111)

## 제목

워크플로우 API의 serialize 과정을 리팩터링한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 워크플로우 API 중에서 create API 에만 serialize 함수가 적용되어 있었으며, 나머지에서는 함수 내에서 직접 serialize 프로세스를 거쳤음.
- serialize를 중복으로 수행하는 코드 섹션이 있었음.

## 변경 후

- create API 뿐만 아니라 다른 API에서도 serialize_workflow() 함수를 이용해 serialize를 진행하도록 수정함.
- get_(job,workflow)_list() 메서드는 model 객체를 포함하는 Queryset을 반환하도록 변경함.
- serialize_workflow() 함수를 model 객체 접근법에 맞춰 serialize 과정을 수행하도록 수정함.
