### PR TITLE
refactor : ZRWC-112 : 워크플로우 Delete API의 실패 시 처리 과정을 리팩터링한다.

### DIFF
--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -70,12 +70,16 @@ class WorkflowAPIView(APIView):
 
         try:
             # Workflow 및 해당 Workflow에 종속된 Jobs를 삭제
-            workflow_service.delete_workflow(workflow_uuid)
+            result = workflow_service.delete_workflow(workflow_uuid)
         except ValidationError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response({'success': f'Workflow with uuid {workflow_uuid} and associated jobs deleted successfully.'},
-                        status=status.HTTP_204_NO_CONTENT)
+        if result:
+            return Response({'success': f'Workflow with uuid {workflow_uuid} and associated jobs deleted successfully.'},
+                            status=status.HTTP_204_NO_CONTENT)
+        else:
+            return Response({'fail': f'Workflow with uuid {workflow_uuid} and associated jobs does not exist.'},
+                            status=status.HTTP_404_NOT_FOUND)
 
 
 class WorkflowListReadAPIView(APIView):

--- a/workflow_engine/project_apps/service/workflow_service.py
+++ b/workflow_engine/project_apps/service/workflow_service.py
@@ -144,6 +144,10 @@ class WorkflowService:
     @transaction.atomic
     def delete_workflow(self, workflow_uuid):
         workflow = self.workflow_repository.get_workflow(workflow_uuid)
+
+        if isinstance(workflow, dict):
+            return False
+
         jobs = self.job_repository.get_job_list(workflow_uuid)
 
         # Workflow 삭제
@@ -152,6 +156,8 @@ class WorkflowService:
         # Jobs 삭제
         for job in jobs:
             self.job_repository.delete_job(job['uuid'])
+
+        return True
 
     def get_workflow_list(self):
         workflows = self.workflow_repository.get_workflow_list()


### PR DESCRIPTION
## Jira 티켓

[ZRWC-112](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-112)

## 제목

워크플로우 Delete API의 실패 시 처리 과정을 리팩터링한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 워크플로우 Delete API 요청을 받아 처리 중 실패 시, (e.g) 존재하지 않는 워크플로우 uuid를 요청) 별도의 처리과정을 거치지 않고 `500 Internal Server Error` 를 반환함.

## 변경 후

- 워크플로우 uuid를 조회했을 때 반환값의 타입에 따라 성공 및 실패 여부를 판단함.
- 처리 실패시 `404 Not Found` 를 반환하도록 수정함.
