### PR TITLE
fix : ZRWC-113 : 스케줄링 CRUD API 관련 버그를 수정한다.

### DIFF
--- a/workflow_engine/project_apps/repository/job_repository.py
+++ b/workflow_engine/project_apps/repository/job_repository.py
@@ -23,9 +23,9 @@ class JobRepository:
             job = Job.objects.get(uuid=job_uuid)
             return job
         except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Workflow not found'}
+            return {'status': 'error', 'message': 'Job not found'}
         except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
+            return {'status': 'error', 'message': 'Multiple Jobs found with the same UUID'}
         except Exception as e:
             return {'status': 'error', 'message': str(e)}
 
@@ -40,9 +40,9 @@ class JobRepository:
 
             return job
         except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Workflow not found'}
+            return {'status': 'error', 'message': 'Job not found'}
         except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
+            return {'status': 'error', 'message': 'Multiple Jobs found with the same UUID'}
         except Exception as e:
             return {'status': 'error', 'message': str(e)}
 

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -17,6 +17,7 @@ class SchedulingRepository:
             interval=parse_interval, 
             repeat_count=repeat_count
         )
+        return scheduling
     
     def get_scheduling(self, scheduling_uuid):
         try:
@@ -33,13 +34,14 @@ class SchedulingRepository:
         scheduling_list = Scheduling.objects.filter(workflow_uuid=workflow_uuid).values('uuid', 'workflow_uuid', 'scheduled_at', 'interval', 'is_active', 'created_at', 'updated_at')
         return list(scheduling_list.values())
 
-    def update_scheduling(self, scheduling_uuid, scheduled_at, interval, repeat_count, is_active):
+    def update_scheduling(self, scheduling_uuid, scheduled_at, interval, repeat_count):
         try:
             scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
             
-            for arg, val in locals().items():
-                if val is not None:
-                    setattr(scheduling, arg, val)
+            scheduling.scheduled_at = parse_datetime(scheduled_at) if scheduled_at else scheduling.scheduled_at
+            scheduling.interval = timedelta(**interval) if interval else scheduling.interval
+            scheduling.repeat_count = repeat_count if repeat_count else scheduling.repeat_count
+
             scheduling.save()
 
             return scheduling

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -18,6 +18,18 @@ class SchedulingService:
             interval=interval,
             repeat_count=repeat_count
         )
+        scheduling_info = {
+            'uuid': scheduling.uuid,
+            'workflow_uuid': scheduling.workflow_uuid,
+            'scheduled_at': scheduling.scheduled_at,
+            'interval': scheduling.interval,
+            'repeat_count': scheduling.repeat_count,
+            'is_active': scheduling.is_active,
+            'created_at': scheduling.created_at,
+            'updated_at': scheduling.updated_at
+        }
+
+        return scheduling_info
 
     def get_scheduling(self, scheduling_uuid):
         scheduling = self.scheduling_repository.get_scheduling(scheduling_uuid)
@@ -58,7 +70,6 @@ class SchedulingService:
             scheduled_at=scheduling_data.get('scheduled_at'),
             interval=scheduling_data.get('interval'),
             repeat_count=scheduling_data.get('repeat_count'),
-            is_active=scheduling_data.get('is_active'),
         )
         scheduling_info = {
             'uuid': scheduling.uuid,


### PR DESCRIPTION
## Jira 티켓

[ZRWC-113](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2/backlog?epics=visible&selectedIssue=ZRWC-113)

## 제목

스케줄링 CRUD API 관련 버그를 수정한다.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 에러처리 메세지 수정 필요
- scheduling_repository.update_scheduling() 메서드에서 에러 발생
- scheduling_service.get_scheduling(), update_scheduling() 메서드에서 에러 발생

## 변경 후

- 상황에 맞는 에러 메세지로 수정
- 모델 객체의 해당 필드를 업데이트하도록 수정
- 변경된 로직에서 is_active 칼럼은 더 이상 수정할 데이터가 아니라서 update_scheduling() 메서드의 매개변수에서 제외함
