### PR TITLE
fix : ZRWC-120 : workflow_engine 컨테이너 내부에서 Docker 데몬과 연결되지 않는 문제를 해결한다.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     command: celery -A workflow_engine worker -l info
     volumes:
       - ./workflow_engine:/app
+      - /var/run/docker.sock:/var/run/docker.sock # Docker 소켓 마운트 추가
     environment:
       CELERY_BROKER_URL: $CELERY_BROKER_URL
       CELERY_RESULT_BACKEND: $CELERY_RESULT_BACKEND

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ typing_extensions==4.9.0
 tzdata==2023.4
 vine==5.1.0
 wcwidth==0.2.13
+docker==7.0.0


### PR DESCRIPTION
## Jira 티켓

[ZRWC-120](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-120)

## 제목

workflow_engine 컨테이너 내부에서 Docker 데몬과 연결되지 않는 문제를 해결한다.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- `docker-compose.yml` 파일을 통해 도커 이미지 빌드 및 컨테이너를 실행 했을 때 워크플로우 실행로직을 실행시키면 때 Docker 데몬과 연결이 되어있지 않다는 에러가 발생하였음.

## 변경 후

- `docker-compose.yml` `celery-worker` 컨테이너내의  `volumes`에 `/var/run/docker.sock:/var/run/docker.sock ` Docker 소켓 마운트를 추가해줌으로써 컨테이너와 도커 데몬이 정상적으로 연결 됨.