### PR TITLE
fix : ZRWC-122 : 의존성이 걸린 작업의 실존 여부를 검사하는 로직을 추가한다.

### DIFF
--- a/workflow_engine/project_apps/service/workflow_service.py
+++ b/workflow_engine/project_apps/service/workflow_service.py
@@ -26,6 +26,14 @@ class WorkflowService:
         입력 받은 데이터를 바탕으로 의존성 카운트를 계산하고, 
         Workflow와 Job 리스트를 생성하고 그 결과를 반환한다.
         '''
+        # 의존성이 걸린 작업의 실존 여부 판별
+        jobs_name = [job_data['name'] for job_data in jobs_data]
+
+        for job_data in jobs_data:
+            for next_job_name in job_data.get('next_job_names', []):
+                if next_job_name not in jobs_name:
+                    return {'status': 'error', 'message': f"Job '{next_job_name}' referenced in next_job_names does not exist"}
+
         workflow = self.workflow_repository.create_workflow(
             name=name, 
             description=description
@@ -70,6 +78,16 @@ class WorkflowService:
         입력 받은 Workflow와 Job 리스트를 주어진 데이터로 수정하고, 
         그 결과를 반환한다.
         '''
+        jobs = self.job_repository.get_job_list(workflow_uuid)
+
+        # 의존성이 걸린 작업의 실존 여부 판별
+        jobs_name = [job.name for job in jobs]
+
+        for job_data in jobs_data:
+            for next_job_name in job_data.get('next_job_names', []):
+                if next_job_name not in jobs_name:
+                    return {'status': 'error', 'message': f"Job '{next_job_name}' referenced in next_job_names does not exist"}
+
         workflow = self.workflow_repository.update_workflow(
             workflow_uuid=workflow_uuid,
             name=workflow_data.get('name'),


### PR DESCRIPTION
## Jira 티켓

[ZRWC-122](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-122)

## 제목

의존성이 걸린 작업의 실존 여부를 검사하는 로직을 추가한다.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 현재 워크플로우 Create, Update API 요청 시에 받는 next_job_names 칼럼에 실존하지 않는 job name이 들어가더라도 데이터가 생성됨.

## 변경 후

- 워크플로우 Create, Update API 요청 시에 요청 된 데이터의 next_job_names 를 확인하여 실존하는 job name 인지 확인한 이후에 기존의 로직이 이어서 실행됨.