### PR TITLE
fix : ZRWC-123 : 워크플로우의 수정된 데이터에 기반한 depends_count 칼럼 값 변경

### DIFF
--- a/workflow_engine/project_apps/service/workflow_service.py
+++ b/workflow_engine/project_apps/service/workflow_service.py
@@ -76,6 +76,13 @@ class WorkflowService:
             description=workflow_data.get('description')
         )
 
+        # 의존성 카운트 계산
+        depends_count = {job_data['name']: 0 for job_data in jobs_data}
+        for job_data in jobs_data:
+            for next_job_name in job_data.get('next_job_names', []):
+                if next_job_name in depends_count:
+                    depends_count[next_job_name] += 1
+
         jobs = []
         for job_data in jobs_data:
             job = self.job_repository.update_job(
@@ -84,7 +91,7 @@ class WorkflowService:
                 image=job_data.get('image'),
                 parameters=job_data.get('parameters'),
                 next_job_names=job_data.get('next_job_names'),
-                depends_count=job_data.get('depends_count'),
+                depends_count=depends_count[job_data['name']],
                 timeout=job_data.get('timeout'),
                 retries=job_data.get('retries')
             )


### PR DESCRIPTION
## Jira 티켓

[ZRWC-123](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-123)

## 제목

워크플로우의 수정된 데이터에 기반한 depends_count 칼럼 값 변경

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 현재 워크플로우 Update API 요청 시, next_job_names 칼럼 값이 수정되더라도 depends_count 가 변경되지 않음.

## 변경 후

- 기존 create_workflow 메서드에 구현된 로직을 사용하여 수정된 데이터에 기반하여 depends_count 칼럼 값도 수정되도록 변경.
