### PR TITLE
refactor : ZRWC-124 : 데이터베이스 HOST값 설정을 env 파일의 POSTGRESQL_HOST 변수를 사용하여 설정한다.

### DIFF
--- a/workflow_engine/workflow_engine/settings.py
+++ b/workflow_engine/workflow_engine/settings.py
@@ -66,10 +66,10 @@ WSGI_APPLICATION = 'workflow_engine.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': env('POSTGRESQL_NAME'), # 데이터베이스 이름
+        'NAME': env('POSTGRESQL_NAME'),
         'USER': env('POSTGRESQL_USER'),
         'PASSWORD': env('POSTGRESQL_PWD'),
-        'HOST': 'db',
+        'HOST': env('POSTGRESQL_HOST'),
         'PORT': env('POSTGRESQL_PORT'),
     }
 }


### PR DESCRIPTION
## Jira 티켓

[ZRWC-124](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-124)

## 제목

데이터베이스 `HOST`값 설정을 `env` 파일의 `POSTGRESQL_HOST` 변수를 사용하여 설정한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 기존 `settings.py` DATABASES 설정에서 `HOST` 값이 `db`로 입력되어있었음.
- `'HOST': 'db'`


## 변경 후

- env 파일에서 `POSTGRESQL_HOST` 변수에 'db'값을 넣어주고 `POSTGRESQL_HOST`를 가져와서 사용하도록 변경한다.
- `HOST': env('POSTGRESQL_HOST')`
- `settings.py` DATABASES 설정 부분 통일성