### PR TITLE
refactor : ZRWC-127 : CRUD API 관련 리팩토링을 진행한다.

### DIFF
--- a/workflow_engine/project_apps/api/serializers.py
+++ b/workflow_engine/project_apps/api/serializers.py
@@ -2,6 +2,12 @@ def serialize_workflow(workflow_info, jobs_data):
     '''
     입력받은 Workflow와 Job 모델 객체를 직렬화한다.
     '''
+    if type(workflow_info) is dict:
+        raise ValueError("요청받은 workflow 정보의 형식이 올바르지 않습니다.")
+    
+    if type(jobs_data[0]) is dict:
+        raise ValueError("요청받은 job 정보의 형식이 올바르지 않습니다.")
+    
     serialized_jobs = []
     for job_data in jobs_data:
         serialized_job = {
@@ -28,6 +34,9 @@ def serialize_workflow(workflow_info, jobs_data):
     return serialized_workflow
 
 def serialize_scheduling(scheduling_info):
+    if type(scheduling_info) is dict:
+        raise ValueError("요청받은 scheduling 정보의 형식이 올바르지 않습니다.")
+    
     serialized_scheduling = {
         'uuid': scheduling_info.uuid,
         'scheduled_at': scheduling_info.scheduled_at,

--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -25,7 +25,7 @@ class WorkflowAPIView(APIView):
         workflow_service = WorkflowService()
         try:
             workflow = workflow_service.create_workflow(name, description, jobs_data)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
         
         return Response(workflow, status=status.HTTP_201_CREATED)
@@ -40,7 +40,7 @@ class WorkflowAPIView(APIView):
         workflow_service = WorkflowService()
         try:
             workflow = workflow_service.get_workflow(workflow_uuid)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
         
         return Response(workflow, status=status.HTTP_200_OK)
@@ -58,7 +58,7 @@ class WorkflowAPIView(APIView):
         workflow_service = WorkflowService()
         try:
             workflow = workflow_service.update_workflow(workflow_uuid, workflow_data, jobs_data)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(workflow, status=status.HTTP_200_OK)
@@ -71,7 +71,7 @@ class WorkflowAPIView(APIView):
 
         try:
             result = workflow_service.delete_workflow(workflow_uuid)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         if result:
@@ -132,7 +132,7 @@ class SchedulingAPIView(APIView):
         scheduling_service = SchedulingService()
         try:
             scheduling = scheduling_service.create_scheduling(workflow_uuid, scheduled_at, interval, repeat_count)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(scheduling, status=status.HTTP_201_CREATED)
@@ -147,7 +147,7 @@ class SchedulingAPIView(APIView):
         scheduling_service = SchedulingService()
         try:
             scheduling = scheduling_service.get_scheduling(scheduling_uuid)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(scheduling, status=status.HTTP_200_OK)
@@ -164,7 +164,7 @@ class SchedulingAPIView(APIView):
         scheduling_service = SchedulingService()
         try:
             scheduling = scheduling_service.update_scheduling(scheduling_uuid, scheduling_data)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(scheduling, status=status.HTTP_200_OK)
@@ -177,7 +177,7 @@ class SchedulingAPIView(APIView):
 
         try:
             scheduling_service.delete_scheduling(scheduling_uuid)
-        except ValidationError as e:
+        except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response({'success': f'Scheduling with uuid {scheduling_uuid} deleted successfully.'},

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -27,12 +27,8 @@ class SchedulingRepository:
                 repeat_count=repeat_count
             )
             return scheduling
-        except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Workflow not found'}
-        except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
         except Exception as e:
-            return {'status': 'error', 'message': str(e)}
+            raise ValueError(str(e))
 
     def get_scheduling(self, scheduling_uuid):
         '''
@@ -41,12 +37,8 @@ class SchedulingRepository:
         try:
             scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
             return scheduling
-        except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Scheduling not found'}
-        except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple schedulings found with the same UUID'}
         except Exception as e:
-            return {'status': 'error', 'message': str(e)}
+            raise ValueError(str(e))
 
     def get_workflow_scheduling_list(self, workflow_uuid):
         '''
@@ -76,12 +68,8 @@ class SchedulingRepository:
             scheduling.save()
 
             return scheduling
-        except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Scheduling not found'}
-        except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple schedulings found with the same UUID'}
         except Exception as e:
-            return {'status': 'error', 'message': str(e)}
+            raise ValueError(str(e))
 
     def delete_scheduling(self, scheduling_uuid):
         '''
@@ -91,9 +79,5 @@ class SchedulingRepository:
             scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
             scheduling.delete()
             return {'status': 'success', 'message': 'Scheduling deleted successfully'}
-        except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Scheduling not found'}
-        except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple Schedulings found with the same UUID'}
         except Exception as e:
-            return {'status': 'error', 'message': str(e)}
+            raise ValueError(str(e))

--- a/workflow_engine/project_apps/repository/workflow_repository.py
+++ b/workflow_engine/project_apps/repository/workflow_repository.py
@@ -11,8 +11,11 @@ class WorkflowRepository:
         '''
         Workflow 정보를 생성한다.
         '''
-        workflow = Workflow.objects.create(name=name, description=description)
-        return workflow
+        try:
+            workflow = Workflow.objects.create(name=name, description=description)
+            return workflow
+        except Exception as e:
+            raise ValueError(str(e))
 
     def get_workflow(self, workflow_uuid):
         '''
@@ -21,12 +24,8 @@ class WorkflowRepository:
         try:
             workflow = Workflow.objects.get(uuid=workflow_uuid)
             return workflow
-        except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Workflow not found'}
-        except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
         except Exception as e:
-            return {'status': 'error', 'message': str(e)}
+            raise ValueError(str(e))
 
     def update_workflow(self, workflow_uuid, name, description):
         '''
@@ -41,12 +40,8 @@ class WorkflowRepository:
             workflow.save()
 
             return workflow
-        except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Workflow not found'}
-        except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
         except Exception as e:
-            return {'status': 'error', 'message': str(e)}
+            raise ValueError(str(e))
 
     def delete_workflow(self, workflow_uuid):
         '''
@@ -56,12 +51,8 @@ class WorkflowRepository:
             workflow = Workflow.objects.get(uuid=workflow_uuid)
             workflow.delete()
             return {'status': 'success', 'message': 'Workflow deleted successfully'}
-        except ObjectDoesNotExist:
-            return {'status': 'error', 'message': 'Workflow not found'}
-        except MultipleObjectsReturned:
-            return {'status': 'error', 'message': 'Multiple workflows found with the same UUID'}
         except Exception as e:
-            return {'status': 'error', 'message': str(e)}
+            raise ValueError(str(e))
 
     def get_workflow_list(self):
         '''

--- a/workflow_engine/project_apps/service/workflow_service.py
+++ b/workflow_engine/project_apps/service/workflow_service.py
@@ -26,13 +26,20 @@ class WorkflowService:
         입력 받은 데이터를 바탕으로 의존성 카운트를 계산하고, 
         Workflow와 Job 리스트를 생성하고 그 결과를 반환한다.
         '''
-        # 의존성이 걸린 작업의 실존 여부 판별
-        jobs_name = [job_data['name'] for job_data in jobs_data]
+        # Job 이름의 중복 여부 판별
+        jobs_name = []
 
+        for job_data in jobs_data:
+            if job_data.get('name') in jobs_name:
+                raise ValueError(f"Multiple Jobs found with the same name {job_data.get('name')}")
+            else:
+                jobs_name.append(job_data.get('name'))
+
+        # 의존성이 걸린 작업의 실존 여부 판별
         for job_data in jobs_data:
             for next_job_name in job_data.get('next_job_names', []):
                 if next_job_name not in jobs_name:
-                    return {'status': 'error', 'message': f"Job '{next_job_name}' referenced in next_job_names does not exist"}
+                    raise ValueError (f"Job '{next_job_name}' referenced in next_job_names does not exist")
 
         workflow = self.workflow_repository.create_workflow(
             name=name, 
@@ -86,7 +93,7 @@ class WorkflowService:
         for job_data in jobs_data:
             for next_job_name in job_data.get('next_job_names', []):
                 if next_job_name not in jobs_name:
-                    return {'status': 'error', 'message': f"Job '{next_job_name}' referenced in next_job_names does not exist"}
+                    raise ValueError(f"'{job_data.get('name')}' references '{next_job_name}' in its next_job_names, but '{next_job_name}' does not exist")
 
         workflow = self.workflow_repository.update_workflow(
             workflow_uuid=workflow_uuid,


### PR DESCRIPTION
## Jira 티켓

[ZRWC-127](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-127)

## 제목

CRUD API 관련 리팩토링을 진행한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전
- CREATE
    - job 생성 시, 종속되는 workflow에 이미 동일한 job.name 이 존재하는 경우에 응답 코드(500)를 반환 함.
   - scheduling 생성 시, 존재하지 않는 workflow에 종속되는 경우에 응답코드(500)를 반환 함.

- UPDATE
    - job 수정시, 종속되는 workflow에 이미 동일한 job.name 이 존재하는 경우에  응답 코드(500)를 반환 함.

- serializer
    - serialize 메서드 매개변수의 타입을 확인하는 로직이 구현되어 있지 않음.

## 변경 후
- serializer.py 파일 수정
    - serialize 메서드에서 매개변수의 타입이 dict 형인지 확인하는 로직이 추가되었음.
        - 이유: 수정 전 로직에서는 레포지토리 및 서비스 계층에서 에러가 발생하면 객체가 아닌 dict 형의 에러메세지를 반환하였기 때문에 매개변수가 dict일 경우는 에러처리된 상황이라고 인지하고 에러메세지를 반환하는 로직으로 수정을 진행함.
        - 참고: 해당 PR에서 수정된 로직에 따르면 레포지토리 및 서비스 계층에서 에러가 발생하게 되면 serialize.py 를 거치지 않고 에러처리가 되도록 수정하였음.

- views.py 파일 수정
    - 예외처리를 ValidationError 에서 ValueError 로 변경하면서 하위 계층에서 발생한 Error를 처리하도록 수정하였음.
    - request.data 를 통해서 발생하는 에러는 모두 응답 코드: 400(bad requets) 으로 처리 하였음.

- repository 계층 수정
    - 예외처리를 raise ValueError 로 변경하면서 에러가 발생하게 되면 바로 에러처리가 되도록 수정하였음.
    - 특히, job_repository.update_job 메서드에서는 IntegrityError 에외처리를 추가하면서 중복된 job name 으로 수정하지 못하도록 수정하였음.

- service 계층 수정
    - job 생성 시, 종속되는 workflow에 이미 동일한 job.name 이 존재하는지 확인하는 로직을 구현 함.