### PR TITLE
feat : ZRWC-128 : 스케줄링이 활성화 상태이면 업데이트가 되지 않도록 구현한다.

### DIFF
--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -154,7 +154,7 @@ class SchedulingAPIView(APIView):
 
     def patch(self, request, scheduling_uuid):
         '''
-        입력 받은 Scheduling을 전송 받은 데이터로 수정한다.
+        Scheduling을 전송 받은 데이터로 수정한다.
         '''
         scheduling_data = request.data
 
@@ -163,11 +163,13 @@ class SchedulingAPIView(APIView):
 
         scheduling_service = SchedulingService()
         try:
-            scheduling = scheduling_service.update_scheduling(scheduling_uuid, scheduling_data)
+            success, result = scheduling_service.update_scheduling(scheduling_uuid, scheduling_data)
+            if success:
+                return Response(result, status=status.HTTP_200_OK)
+            else:
+                return Response({"error": result}, status=status.HTTP_400_BAD_REQUEST)
         except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-        return Response(scheduling, status=status.HTTP_200_OK)
 
     def delete(self, request, scheduling_uuid):
         '''

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -79,6 +79,11 @@ class SchedulingService:
         '''
         입력 받은 Scheduling을 전송 받은 데이터로 수정한다.
         '''
+        scheduling = self.scheduling_repository.get_scheduling(scheduling_uuid)
+
+        if scheduling.is_active:
+            return False, "스케줄링이 이미 활성화되었으므로 업데이트할 수 없습니다."
+         
         scheduling = self.scheduling_repository.update_scheduling(
             scheduling_uuid,
             scheduled_at=scheduling_data.get('scheduled_at'),
@@ -86,7 +91,7 @@ class SchedulingService:
             repeat_count=scheduling_data.get('repeat_count'),
         )
 
-        return serialize_scheduling(scheduling)
+        return True, serialize_scheduling(scheduling)
 
     @transaction.atomic
     def delete_scheduling(self, scheduling_uuid):


### PR DESCRIPTION
## Jira 티켓

[ZRWC-128](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-128)

## 제목

스케줄링이 활성화 상태이면 업데이트가 되지 않도록 구현한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 스케줄링이 이미 활성화 상태일때도 스케줄링 데이터 값이 변경되고 있음.

## 변경 후

- 스케줄링 update 요청 시 스케줄링 업데이트 서비스 로직에서 해당 스케줄링 `is_active` 상태를 검사하고 `True` 이면 업데이트가 안되도록 구현.