### PR TITLE
feat : ZRWC-129 : 실행중인 스케줄링을 임의로 비활성화 상태로 변경할 수 있는 로직을 구현한다.

### DIFF
--- a/workflow_engine/project_apps/api/urls.py
+++ b/workflow_engine/project_apps/api/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path('scheduling/<uuid:scheduling_uuid>', SchedulingUUIDAPIView.as_view()),
     path('scheduling/workflow/<uuid:workflow_uuid>', SchedulingWorkflowAPIView.as_view()),
     path('scheduling/<uuid:scheduling_uuid>/execute', SchedulingExecuteAPIView.as_view()),
+    path('scheduling/<uuid:scheduling_uuid>/deactive', SchedulingDeactivateAPIView.as_view()),
 ]

--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -230,3 +230,20 @@ class SchedulingExecuteAPIView(APIView):
             return Response({"error": message}, status=400)
 
         return Response({"message": message})
+
+
+class SchedulingDeactivateAPIView(APIView):
+    '''
+    Scheduling을 비활성화하는 API.
+    '''
+    def post(self, request, scheduling_uuid):
+        '''
+        입력 받은 Scheduling을 비활성화한다.
+        '''
+        scheduling_service = SchedulingService()
+        success, message = scheduling_service.deactivate_scheduling(scheduling_uuid)
+
+        if not success:
+            return Response({"error": message}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response({"message": message}, status=status.HTTP_200_OK)

--- a/workflow_engine/project_apps/api/views.py
+++ b/workflow_engine/project_apps/api/views.py
@@ -227,9 +227,9 @@ class SchedulingExecuteAPIView(APIView):
         success, message = scheduling_service.activate_scheduling(scheduling_uuid)
 
         if not success:
-            return Response({"error": message}, status=400)
+            return Response({"error": message}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response({"message": message})
+        return Response({"message": message}, status=status.HTTP_200_OK)
 
 
 class SchedulingDeactivateAPIView(APIView):

--- a/workflow_engine/project_apps/engine/scheduling_execute.py
+++ b/workflow_engine/project_apps/engine/scheduling_execute.py
@@ -17,6 +17,10 @@ def execute_scheduling(scheduling_uuid):
     '''
     scheduling = scheduling_repo.get_scheduling(scheduling_uuid)
 
+    if not scheduling.is_active:
+        print(f"{scheduling_uuid} 스케줄링이 비활성화 상태로 변경되었습니다. 실행을 종료합니다")
+        return
+
     execute_scheduling_workflow(scheduling)
 
     if not scheduling.interval:

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -81,3 +81,15 @@ class SchedulingRepository:
             return {'status': 'success', 'message': 'Scheduling deleted successfully'}
         except Exception as e:
             raise ValueError(str(e))
+        
+    def deactivate_scheduling(self, scheduling_uuid):
+        '''
+        일치하는 Scheduling를 비활성화한다.
+        '''
+        try:
+            scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
+            scheduling.is_active = False
+            scheduling.save()
+            return True, "스케줄링이 비활성화되었습니다."
+        except Exception as e:
+            raise ValueError(str(e))

--- a/workflow_engine/project_apps/repository/scheduling_repository.py
+++ b/workflow_engine/project_apps/repository/scheduling_repository.py
@@ -82,6 +82,18 @@ class SchedulingRepository:
         except Exception as e:
             raise ValueError(str(e))
         
+    def activate_scheduling(self, scheduling_uuid):
+        '''
+        일치하는 Scheduling를 활성화한다.
+        '''
+        try:    
+            scheduling = Scheduling.objects.get(uuid=scheduling_uuid)
+            scheduling.is_active = True
+            scheduling.save()
+            return True, "스케줄링이 활성화되었습니다."
+        except Exception as e:
+            raise ValueError(str(e))
+
     def deactivate_scheduling(self, scheduling_uuid):
         '''
         일치하는 Scheduling를 비활성화한다.

--- a/workflow_engine/project_apps/service/scheduling_service.py
+++ b/workflow_engine/project_apps/service/scheduling_service.py
@@ -124,3 +124,17 @@ class SchedulingService:
             execute_scheduling.delay(scheduling_uuid)
 
         return True, "스케줄링이 활성화되었습니다. 예정된 시간에 실행됩니다."
+
+    @transaction.atomic
+    def deactivate_scheduling(self, scheduling_uuid):
+        '''
+        입력 받은 Scheduling을 비활성화한다.
+        '''
+        scheduling = self.scheduling_repository.get_scheduling(scheduling_uuid)
+
+        if not scheduling.is_active:
+            return False, "스케줄링이 이미 비활성화되어 있습니다."
+
+        success, message = self.scheduling_repository.deactivate_scheduling(scheduling_uuid)
+
+        return success, message


### PR DESCRIPTION
## Jira 티켓

[ZRWC-129](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-129)

## 제목

실행중인 스케줄링을 임의로 비활성화 상태로 변경할 수 있는 로직 구현 및 스케줄링 활성화 로직 분리

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 스케줄링이 활성화가 된 후 임의로 비활성화 상태로 변경할 수 없었음.
- 스케줄링 활성화 is_active 값을 변경하고 데이터베이스에 저장하는 로직이 서비스 로직에 존재하였음.


## 변경 후

- 스케줄링이 활성화가 된 후에도 임의로 비활성화 상태로 변경할 수 있음.
- 스케줄링 활성화 데이터 관련 로직은 레포지토리 로직으로 분리.