### PR TITLE
refactor : ZRWC-131 : Job 테이블 수정 시에, Job uuid 와 수정할 칼럼 데이터만 입력받도록 로직 구현

### DIFF
--- a/workflow_engine/project_apps/service/workflow_service.py
+++ b/workflow_engine/project_apps/service/workflow_service.py
@@ -100,9 +100,8 @@ class WorkflowService:
 
         for job_data in jobs_data:
             job_uuid = uuid.UUID(job_data['uuid'])
-            job_name = job_data['name']
-
             current_job = existing_jobs_dict.get(job_uuid)
+            job_name = job_data.get('name') if job_data.get('name') else current_job.name
 
             new_next_job_names = job_data.get('next_job_names', [])
             for next_job_name in new_next_job_names:
@@ -124,11 +123,11 @@ class WorkflowService:
             job_updates[job_uuid] = {
                 "uuid": job_uuid,
                 "name": job_name,
-                "image": job_data['image'],
-                "parameters": job_data['parameters'],
-                "next_job_names": new_next_job_names,
-                "timeout": job_data.get('timeout', 0),
-                "retries": job_data.get('retries', 0),
+                "image": job_data.get('image') if job_data.get('image') else current_job.image,
+                "parameters": job_data.get('parameters') if job_data.get('parameters') else current_job.parameters,
+                "next_job_names": new_next_job_names if job_data.get('next_job_names') else current_job.next_job_names,
+                "timeout": job_data.get('timeout') if job_data.get('timeout') else current_job.timeout,
+                "retries": job_data.get('retries') if job_data.get('retries') else current_job.retries,
                 "depends_count": existing_jobs_dict[job_uuid].depends_count if job_uuid in existing_jobs_dict else 0
             }
 


### PR DESCRIPTION
## Jira 티켓

[ZRWC-131](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-131)

## 제목

Job 테이블 수정 시에, Job uuid 와 수정할 칼럼 데이터만 입력받도록 로직 구현

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- Job 테이블을 수정하려면 해당 테이블의 모든 칼럼 데이터를 입력해줘야만 했음.

## 변경 후

- Job 테이블을 수정하려면 해당 Job 의 uuid 와 변경하고자 하는 칼럼 데이터만 입력해도 수정 됨.
