### PR TITLE
fix : ZRWC-135 : 워크플로우 실행로직에서 워크플로우의 상태에 따라 다른 반환 값을 제공하도록 수정한다.

### DIFF
--- a/workflow_engine/project_apps/engine/job_execute.py
+++ b/workflow_engine/project_apps/engine/job_execute.py
@@ -21,7 +21,8 @@ def job_trial(workflow_uuid, history_uuid, job_uuid):
     
     retries = job_data['retries']
     for _ in range(retries+1):
-        if job_execute(workflow_uuid, history_uuid, job_uuid):
+        result = job_execute(workflow_uuid, history_uuid, job_uuid)
+        if result is not None:
             return
     
     workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_FAIL)
@@ -63,10 +64,10 @@ def job_execute(workflow_uuid, history_uuid, job_uuid):
             container.remove()
             return True
         else:
-            return False
+            return None
 
     except (ReadTimeout, ConnectionError, ImageNotFound, APIError) as e:
-        return False
+        return None
 
     except Exception as e:
-        return False
+        return None

--- a/workflow_engine/project_apps/service/workflow_manage.py
+++ b/workflow_engine/project_apps/service/workflow_manage.py
@@ -1,6 +1,6 @@
 import orjson as json
 
-from project_apps.constants import HISTORY_STATUS_FAIL, HISTORY_STATUS_SUCCESS, JOB_STATUS_SUCCESS, WORKFLOW_STATUS_FAIL, WORKFLOW_STATUS_SUCCESS
+from project_apps.constants import HISTORY_STATUS_FAIL, HISTORY_STATUS_SUCCESS, JOB_STATUS_SUCCESS, JOB_STATUS_FAIL, WORKFLOW_STATUS_FAIL, WORKFLOW_STATUS_SUCCESS
 from project_apps.engine.job_terminate import job_terminate
 from project_apps.engine.tasks_manager import job_dependency
 from project_apps.models.cache import Cache
@@ -38,12 +38,13 @@ class WorkflowManager:
 
         workflow_status = self.check_workflow_status(workflow_uuid)
         if workflow_status == WORKFLOW_STATUS_FAIL:
-            for job in workflow_data:
-                if job['uuid'] == str(job_uuid):
-                    job['result'] = status
-                    print(f"{job['uuid'], job['result']}")
-                    break
-            self.cache.set(workflow_uuid, json.dumps(workflow_data))
+            if status == JOB_STATUS_FAIL:
+                for job in workflow_data:
+                    if job['uuid'] == str(job_uuid):
+                        job['result'] = status
+                        print(f"{job['uuid'], job['result']}")
+                        break
+                self.cache.set(workflow_uuid, json.dumps(workflow_data))
             return False
         else:
             for job in workflow_data:


### PR DESCRIPTION
## Jira 티켓

[ZRWC-135](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-135)

## 제목

워크플로우 실행로직에서 워크플로우의 상태에 따라 다른 반환 값을 제공하도록 수정한다.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 워크플로우 상태가 실패처리 되었을경우 동시에 실행중이였던 다른 job들도 워크플로우 상태가 실패처리가 되어있기 때문에 `update_job_status` 에서 False값을 반환받게 되고 그럼으로 `job_trial` task에서 해당 job의 `retries` 값만큼 반복적으로 해당 job을 실행하게 되고 결론적으로 return 되지 못한채 job 실패 시 호출되는 메서드를 호출하고 있다.

[실패로직 시 호출되는 메서드]
`workflow_manager.update_job_status(workflow_uuid, job_uuid, JOB_STATUS_FAIL)`
`workflow_manager.handle_failure(workflow_uuid, history_uuid)`

- 그러므로 동시에 실행중인 job이 정상적으로 실행중이였어도 실패로직을 호출하게 되고 그로인해 불필요하게 해당 실패처리 메서드를 여러 번 호출하게 된다.

## 변경 후

[실행 로직 이해 배경]
- 워크플로우 실행 로직은 워크플로우의 상태를 주기적으로 검사(`update_job_status`, `workflow_manager.check_workflow_status`)하여 현재 진행 상황을 반영하고 있다. 
- `job_trial` task 로직에서
```
for _ in range(retries+1):
        result = job_execute(workflow_uuid, history_uuid, job_uuid)
        if result is not None:
            return
```
`result`값 즉 `job_execute` 반환 값이 `None` 값이 아닐 경우에 즉각적으로 return되고 종료되도록 수정하였다.


[변경사항]
- `job_trial` task에서 result값 즉 `job_execute` 반환 값이 `None` 값이 아닐 경우에 즉각적으로 return되고 종료되도록 수정하였다.
- 워크플로우의 상태가 이미 실패상태라면, 실행로직은 즉각적으로 `False` 값을 반환함으로써 해당 워크플로우의 진행을 중단. (기존과 동일) 이를 통해 `job_trial` task에서 불필요하게 job 실패로직을 호출하지 않도록 수정하였다.
- 워크플로우가 실패 상태가 아니며 job이 정상적으로 실행되어 성공적으로 종료된 경우에는 `True` 값을 반환. (기존과 동일)
- 만약 워크플로우가 실패 상태가 아니였을때 특정 job의 실행에 실패한 경우, 로직은 `None` 값을 반환한다. (수정사항) 이를 통해 `job_trial` task에서 적절하게 재시도 로직이 실행되도록 수정하였다.
