### PR TITLE
refactor : ZRWC-137 : 워크플로우 종료(성공/실패)시 터미널에 종료 메세지를 출력한다.

### DIFF
--- a/workflow_engine/project_apps/service/workflow_manage.py
+++ b/workflow_engine/project_apps/service/workflow_manage.py
@@ -66,6 +66,10 @@ class WorkflowManager:
             if running_containers:
                 for container_id in running_containers:
                     job_terminate.apply_async(args=[container_id])
+            print(f"Workflow {workflow_uuid} has failed and is now terminated.")
+
+        else:
+            print(f"Workflow {workflow_uuid} has successfully completed and is now terminated.")
     
     def check_workflow_status(self, workflow_uuid):
         '''


### PR DESCRIPTION
## Jira 티켓

[ZRWC-137](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2?selectedIssue=ZRWC-137)

## 제목

워크플로우 종료(성공/실패)시 터미널에 종료 메세지를 출력한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 워크플로우가 종료되는 시점에 해당 워크플로우에 대한 종료기록이 history 레코드에는 기록되어 저장되지만 터미널에는 별다른 메세지가 없어서 개발자가 한 눈에 확인하기 어려웠음.

## 변경 후

- 워크플로우가 종료되는 시점에 워크플로우 성공적으로 종료되었는지, 실패상태로 종료되었는지 대한 종료 메세지 터미널에 출력되도록 수정하였음.
