### PR TITLE
chore : ZRWC-132 : drf-yasg 라이브러리 requirements.txt에 추가한다.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ tzdata==2023.4
 vine==5.1.0
 wcwidth==0.2.13
 docker==7.0.0
+drf-yasg==1.21.7


### PR DESCRIPTION
## Jira 티켓

[ZRWC-132](https://workflow-engine.atlassian.net/jira/software/projects/ZRWC/boards/2/timeline?selectedIssue=ZRWC-132)

## 제목

drf-yasg 라이브러리 requirements.txt에 추가한다.

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 리팩터링(Refactoring)
- [x] 문서 추가/수정
- [ ] 기타:

## 변경 전

- requirements.txt에 drf-yasg 라이브러리를  명시해주지 않았음.
- 도커 환경에서 실행시킬때 drf-yasg가 설치되어있지 않다는 에러가 발생하였음.

## 변경 후

- requirements.txt에 drf-yasg==1.21.7 를 추가하였음.
